### PR TITLE
修改原生的 Object.keys 为单独的函数

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict';
 /* eslint space-before-function-paren: 0 */
 
-Object.keys = function (obj) {
+Keys = function (obj) {
   var keys = [];
   for (var k in obj) {
     if (typeof k === 'string') {
@@ -26,7 +26,7 @@ var validator = {
     var params = validator._getParams(confs);
     var ignores = validator._getIgnores(confs);
     var extracted = validator.extract(data, params);
-    if (Object.keys(extracted).length <= 0) {
+    if (Keys(extracted).length <= 0) {
       return false;
     }
     var error = validator._validate(extracted, confs);
@@ -87,7 +87,7 @@ var validator = {
           break;
       }
     }
-    if (!Object.keys(data).length) {
+    if (!Keys(data).length) {
       return false;
     }
     return data;


### PR DESCRIPTION
修改原生的 Object.keys ( https://es5.github.io/#x15.2.3.14 ) 会导致别的程序产生不可预见的错误。
比如 request 模块
TypeError: self.start is not a function
    at Socket.Request.write [as _write](node_modules/request/request.js:1384:10)
